### PR TITLE
Added fetch security

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 config.env
 package-lock.json 
+.env

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import ChatMessage from "./components/ChatMessage";
 const App = () => {
   const [chatHistory, setChatHistory] = useState([]);
   const chatBodyRef = useRef();
+  const fetchURL = import.meta.env.VITE_FETCH_URL;
 
   /**
    * Sends the latest user message to the server and updates chat history with the bot's response.
@@ -20,7 +21,7 @@ const App = () => {
     const lastMessage = history[history.length - 1];
   
     try {
-      const response = await fetch("http://localhost:5001/ask", {
+      const response = await fetch(fetchURL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ question: lastMessage.text }),


### PR DESCRIPTION
Allows you to change the URL of where you are fetching from in a .env. This is required if we want to deploy online with a separate frontend/backend. 
All that needs to be done on a developer's end is to create a new **.env** in the root of frontend with a **VITE_FETCH_URL** env that states the link it wants to fetch from. 